### PR TITLE
Document and add use_cdn option for api configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Sanity.configure do |s|
   s.api_version = "v2021-03-25"
   s.project_id = "1234"
   s.dataset = "development"
+  s.use_cdn = false
 end
 ```
 

--- a/lib/sanity/configuration.rb
+++ b/lib/sanity/configuration.rb
@@ -24,6 +24,11 @@ module Sanity
       @token = ""
       @use_cdn = false
     end
+
+    # @return [String] Api subdomain based on use_cdn flag
+    def api_subdomain
+      use_cdn ? "apicdn" : "api"
+    end
   end
 
   def self.configuration

--- a/lib/sanity/http/mutation.rb
+++ b/lib/sanity/http/mutation.rb
@@ -10,7 +10,7 @@ module Sanity
         def included(base)
           base.extend(ClassMethods)
           base.extend(Forwardable)
-          base.delegate(%i[project_id api_version dataset token] => :"Sanity.config")
+          base.delegate(%i[project_id api_version dataset token api_subdomain] => :"Sanity.config")
           base.delegate(mutatable_api_endpoint: :resource_klass)
         end
       end
@@ -66,7 +66,7 @@ module Sanity
       private
 
       def base_url
-        "https://#{project_id}.api.sanity.io/#{api_version}/#{mutatable_api_endpoint}/#{dataset}"
+        "https://#{project_id}.#{api_subdomain}.sanity.io/#{api_version}/#{mutatable_api_endpoint}/#{dataset}"
       end
 
       def body

--- a/lib/sanity/http/query.rb
+++ b/lib/sanity/http/query.rb
@@ -11,7 +11,7 @@ module Sanity
         def included(base)
           base.extend(ClassMethods)
           base.extend(Forwardable)
-          base.delegate(%i[project_id api_version dataset token] => :"Sanity.config")
+          base.delegate(%i[project_id api_version dataset token api_subdomain] => :"Sanity.config")
         end
       end
 
@@ -56,7 +56,7 @@ module Sanity
       end
 
       def base_url
-        "https://#{project_id}.api.sanity.io/#{api_version}/#{api_endpoint}/#{dataset}"
+        "https://#{project_id}.#{api_subdomain}.sanity.io/#{api_version}/#{api_endpoint}/#{dataset}"
       end
 
       def headers

--- a/test/sanity/configuration_test.rb
+++ b/test/sanity/configuration_test.rb
@@ -10,4 +10,15 @@ describe Sanity::Configuration do
   it { assert_equal "", subject.api_version }
   it { assert_equal "", subject.token }
   it { refute subject.use_cdn }
+
+  describe "#api_subdomain" do
+    context "when use_cdn is false" do
+      it { assert_equal "api", subject.api_subdomain }
+    end
+
+    context "when use_cdn is true" do
+      before { subject.stubs(use_cdn: true) }
+      it { assert_equal "apicdn", subject.api_subdomain }
+    end
+  end
 end


### PR DESCRIPTION
This commit allows a user to configure their interaction with the sanity
cdn api.

Related sanity docs: https://www.sanity.io/docs/api-cdn