### PR TITLE
Add sanity-ruby.rb so gem auto-requires

### DIFF
--- a/lib/sanity-ruby.rb
+++ b/lib/sanity-ruby.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'sanity'

--- a/lib/sanity-ruby.rb
+++ b/lib/sanity-ruby.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require 'sanity'
+require "sanity"


### PR DESCRIPTION
This gem is named `sanity-ruby` externally, but internally it's called just plain `sanity`. This doesn't follow Bundler's standard naming conventions, so it won't be automatically required by Bundler. I spent a couple of hours this afternoon trying to figure out why the gem wasn't working in my Rails app. I couldn't even get it to load in IRB until, on a whim, I tried `require 'sanity'`.

This PR allows Bundler to require it automatically by adding `lib/sanity-ruby.rb`, which is just a dummy file to require the Sanity gem. Thanks for the gem!