### PR TITLE
fix: use correct symbol for find by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Sanity::Document.patch(params: { _id: "1234-321", set: { first_name: "Carl" }})
 To [find document(s) by id](https://www.sanity.io/docs/http-doc):
 
 ```ruby
-Sanity::Document.find(_id: "1234-321")
+Sanity::Document.find(id: "1234-321")
 ```
 
 To find documents based on certain fields:

--- a/lib/sanity/http/find.rb
+++ b/lib/sanity/http/find.rb
@@ -11,7 +11,7 @@ module Sanity
 
       def initialize(**args)
         super
-        @id = args.delete(:id)
+        @id = args.delete(:_id)
       end
 
       private

--- a/lib/sanity/http/find.rb
+++ b/lib/sanity/http/find.rb
@@ -11,7 +11,7 @@ module Sanity
 
       def initialize(**args)
         super
-        @id = args.delete(:_id)
+        @id = args.delete(:id)
       end
 
       private

--- a/test/sanity/http/find_test.rb
+++ b/test/sanity/http/find_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Sanity::Http::Find do
+  let(:klass) { Sanity::Http::Find }
+
+  it do
+    assert_equal klass.new(_id: 'test_123').id, 'test_123'
+  end
+end

--- a/test/sanity/http/find_test.rb
+++ b/test/sanity/http/find_test.rb
@@ -6,6 +6,6 @@ describe Sanity::Http::Find do
   let(:klass) { Sanity::Http::Find }
 
   it do
-    assert_equal klass.new(_id: 'test_123').id, 'test_123'
+    assert_equal klass.new(id: 'test_123').id, 'test_123'
   end
 end


### PR DESCRIPTION
According to the documentation, retrieving a document by ID is supposed to be done like:
```ruby
Sanity::Document.find(_id: "my-id")
```

but the `Sanity::Http::Find` class was trying to look for `:id`, and so the request was failing.

Updated to use `:_id`, and added a corresponding test.