### PR TITLE
Added support for serialization, attribute aliases and types, other refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library also provides other features, like:
 
 - Easy configuration for fast setup and use.
 - A pre-defined class to help make any PORO a "sanity resource"
-- Extensibility in overriding the wrapper of your API response results
+- Extensibility in overriding the serializer for the API response results
 - A small DSL around GROQ queries
 
 ## Contents
@@ -17,6 +17,7 @@ The library also provides other features, like:
 - [Sanity](#sanity)
   - [Contents](#contents)
   - [Getting Started](#getting-started)
+  - [Serialization](#serialization)
   - [Mutating](#mutating)
   - [Querying](#querying)
   - [Development](#development)
@@ -70,6 +71,8 @@ To make any PORO a sanity resource:
 class User < Sanity::Resource
   attribute :_id, default: ""
   attribute :_type: default: ""
+  # optional type support (Boolean, Float, Integer, or Time)
+  attribute :login_count, type: :integer
   mutatable only: %i(create delete)
   queryable
 end
@@ -98,6 +101,34 @@ class User
   queryable
   mutatable
 end
+```
+
+## Serialization
+
+When using a PORO, you can opt-in to automatically serialize your results.
+
+```ruby
+class User < Sanity::Resource
+  auto_serialize
+  ...
+end
+```
+
+Additionally, you can configure a custom serializer. See how to define a custom
+serializer [below](#custom-serializer).
+
+```ruby
+class User < Sanity::Resource
+  serializer UserSerializer
+  ...
+end
+```
+
+Finally, at query time you can also pass in a serializer. A serializer specified
+at query time will take priority over any other configuration.
+
+```ruby
+User.where(active: true, serializer: UserSerializer)
 ```
 
 ## Mutating
@@ -217,6 +248,35 @@ GROQ
 
 Sanity::Document.where(groq: groq_query, variables: {name: "Monsters, Inc."})
 ```
+
+## Custom serializer
+
+```ruby
+class UserSerializer
+  class << self
+    def call(...)
+      new(...).call
+    end
+  end
+
+  attr_reader :results
+
+  def initialize(args)
+    @results = args["result"]
+  end
+
+  def call
+    results.map do |result|
+      User.new(
+        _id: result["_id"],
+        _type: result["_type"]
+      )
+    end
+  end
+end
+```
+
+
 
 ## Development
 

--- a/lib/sanity.rb
+++ b/lib/sanity.rb
@@ -12,6 +12,7 @@ require "sanity/http"
 require "sanity/attributable"
 require "sanity/mutatable"
 require "sanity/queryable"
+require "sanity/serializable"
 
 require "sanity/resource"
 require "sanity/resources"

--- a/lib/sanity/attributable.rb
+++ b/lib/sanity/attributable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'time'
 
 module Sanity
   # Attributable is responsible for setting the appropriate attributes
@@ -9,6 +10,12 @@ module Sanity
   #
   # @example provides getter and setter methods for `_id` and sets the default value to an empty string
   #   attribute :_id, default: ""
+  #
+  # @example provides ability to set a type (currently supports :boolean, :float, :intger, or :time)
+  #   attribute :login_count, type: :integer
+  #
+  # @example provides getter and setter methods for both `_id` and the alias `id`
+  #   attribute :_id, alias: :id
   #
   module Attributable
     class << self
@@ -22,33 +29,47 @@ module Sanity
         @attributes ||= []
       end
 
-      def default_attributes
-        @defaults ||= {}
+      def aliased_attributes
+        @aliased_attributes ||= {}
       end
 
       private
 
-      def attribute(name, default: nil)
-        attributes << name
-        default_attributes.merge!("#{name}": default)
+      def attribute(name, default: nil, alias: nil, type: nil)
+        attributes.push(name)
+
+        self.define_method("#{name}=") do |value|
+          @attributes[name] =
+            case type
+            when :boolean
+              value.to_s == 'true'
+            when :float
+              value.to_f
+            when :integer
+              value.to_i
+            when :time
+              Time.parse(value.to_s)
+            else
+              value
+            end
+        end
+        self.define_method("#{name}") { @attributes[name] }
+
+        alias_name = binding.local_variable_get('alias')
+        if alias_name
+          aliased_attributes[alias_name] = name
+          self.alias_method("#{alias_name}=", "#{name}=")
+          self.alias_method(alias_name, name)
+        end
       end
+
     end
 
     attr_reader :attributes
 
-    def initialize(**args)
-      self.class.default_attributes.merge(args).then do |attrs|
-        attrs.each do |key, val|
-          define_singleton_method("#{key}=") do |val|
-            args[key] = val
-            attributes[key] = val
-          end
-
-          define_singleton_method(key) { args[key] }
-        end
-
-        instance_variable_set(:@attributes, attrs)
-      end
+    def initialize(**kwargs)
+      @attributes ||= {}
+      kwargs.each { |name, value| public_send("#{name}=", value) }
     end
 
     def inspect

--- a/lib/sanity/http/where.rb
+++ b/lib/sanity/http/where.rb
@@ -18,7 +18,9 @@ module Sanity
         @variables = args.delete(:variables) || {}
         @use_post = args.delete(:use_post) || false
 
-        @groq_attributes = args.except(:groq, :use_post, :resource_klass, :result_wrapper)
+        @groq_attributes = args.except(
+          :groq, :use_post, :resource_klass, :serializer, :result_wrapper
+        )
       end
 
       private

--- a/lib/sanity/mutatable.rb
+++ b/lib/sanity/mutatable.rb
@@ -36,7 +36,15 @@ module Sanity
         options.fetch(:only, ALL_MUTATIONS).each do |mutation|
           if DEFAULT_KLASS_MUTATIONS.include? mutation.to_sym
             define_singleton_method(mutation) do |**args|
-              Module.const_get("Sanity::Http::#{mutation.to_s.classify}").call(**args.merge(resource_klass: self))
+              default_args = { resource_klass: self }
+              if !self.is_a?(Sanity::Document)
+                default_type = self.to_s
+                default_type[0] = default_type[0].downcase
+                default_args.merge!(_type: default_type)
+              end
+              Module.const_get("Sanity::Http::#{mutation.to_s.classify}").call(
+                **args.merge(default_args)
+              )
             end
           end
 

--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -40,7 +40,15 @@ module Sanity
       def queryable(**options)
         options.fetch(:only, DEFAULT_KLASS_QUERIES).each do |query|
           define_singleton_method(query) do |**args|
-            Module.const_get("Sanity::Http::#{query.to_s.classify}").call(**args.merge(resource_klass: self))
+            default_args = { resource_klass: self }
+            if !self.is_a?(Sanity::Document)
+              default_type = self.to_s
+              default_type[0] = default_type[0].downcase
+              default_args.merge!(_type: default_type)
+            end
+            Module.const_get("Sanity::Http::#{query.to_s.classify}").call(
+              **args.merge(default_args)
+            )
           end
           define_singleton_method("#{query}_api_endpoint") { QUERY_ENDPOINTS[query] }
         end

--- a/lib/sanity/resource.rb
+++ b/lib/sanity/resource.rb
@@ -8,6 +8,7 @@ module Sanity
   #   Sanity::Attributable
   #   Sanity::Mutatable
   #   Sanity::Queryable
+  #   Sanity::Serializable
   #
   # Sanity::Document and Sanity::Asset both inherit
   # from Sanity::Resource
@@ -26,5 +27,6 @@ module Sanity
     include Sanity::Attributable
     include Sanity::Mutatable
     include Sanity::Queryable
+    include Sanity::Serializable
   end
 end

--- a/lib/sanity/serializable.rb
+++ b/lib/sanity/serializable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Sanity
+  # Serializable is responsible for configuring auto serialization or a default
+  # serializer. It also defines the default class serializer used when auto
+  # serialization is enabled.
+  #
+  # The auto_serialize macro is used to enable auto serialization.
+  #
+  # @example enables auto serialization
+  #   auto_serialize
+  #
+  # The serializer marco is used to define the default serializer.
+  #
+  # @example default to using a custom defined UserSerializer
+  #   serializer UserSerializer
+  #
+  module Serializable
+    class << self
+      def included(base)
+        base.extend(ClassMethods)
+      end
+    end
+
+    module ClassMethods
+      def default_serializer
+        @default_serializer
+      end
+
+      private
+
+      def auto_serialize
+        @default_serializer = class_serializer
+      end
+
+      def serializer(serializer)
+        @default_serializer = serializer
+      end
+
+      def class_serializer
+        Proc.new do |results|
+          results['result'].map do |result|
+            attributes = result.slice(*self.attributes.map(&:to_s))
+            self.new(**attributes.transform_keys(&:to_sym))
+          end
+        end
+      end
+
+    end
+
+    attr_reader :default_serializer
+
+  end
+end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -7,7 +7,8 @@ describe Sanity::Resource do
   subject { klass.new }
 
   it { assert_respond_to klass, :attributes }
-  it { assert_respond_to klass, :default_attributes }
+  it { assert_respond_to klass, :aliased_attributes }
+  it { assert_respond_to klass, :default_serializer }
 
   it { assert_respond_to subject, :attributes }
 end


### PR DESCRIPTION
I put togather a bunch of changes that I think are really nice to have. After thinking about what we discussed in #19, I decided that `serializer` was a better term than `result_wrapper`. Let me know if you want me to add anything or make any changes. Below is a summary of what I added and changed. I'm not 100% familiar with every part of this gem so hopefully I didn't miss anything.

- Added support for serialization
  - Added `auto_serialize` option to opt-in to automatic serialization using the PORO as the serializer.
  - Added `serialize` option to configure a custom serializer.
- Added support for aliasing attributes
- Added support for optional attribute types.
- Changed `result_wrapper` to be `serializer`, but left `result_wrapper` options in place to allow backwards compatibility.
- Added default type using PORO.
- Refactored Sanity::Attributable to define it's methods at class defintion instead of at instance initialization so you can override getter or setters if you'd like.