### PR TITLE
Added support to attributes for aliasing and native types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,17 @@ To create a new asset:
 
 To make any PORO a sanity resource:
 
+| Option  | Description |
+| --------| ------------|
+| default | set a default value. |
+| as | provides aliased getter and setter methods. |
+| type | converts value to one of Boolean, Float, Integer, or Time |
+
 ```ruby
 class User < Sanity::Resource
-  attribute :_id, default: ""
-  attribute :_type: default: ""
+  attribute :_id, as: :id, default: ""
+  attribute :_createdAt, as: :created_at
+  attribute :login_count, type: :integer
   mutatable only: %i(create delete)
   queryable
 end

--- a/lib/sanity/attributable.rb
+++ b/lib/sanity/attributable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'time'
 
 module Sanity
   # Attributable is responsible for setting the appropriate attributes
@@ -9,6 +10,12 @@ module Sanity
   #
   # @example provides getter and setter methods for `_id` and sets the default value to an empty string
   #   attribute :_id, default: ""
+  #
+  # @example provides ability to set a type (currently supports :boolean, :float, :intger, or :time)
+  #   attribute :login_count, type: :integer
+  #
+  # @example provides getter and setter methods for both `_id` and the alias `id`
+  #   attribute :_id, as: :id
   #
   module Attributable
     class << self
@@ -22,33 +29,46 @@ module Sanity
         @attributes ||= []
       end
 
-      def default_attributes
-        @defaults ||= {}
+      def aliased_attributes
+        @aliased_attributes ||= {}
       end
 
       private
 
-      def attribute(name, default: nil)
-        attributes << name
-        default_attributes.merge!("#{name}": default)
+      def attribute(name, default: nil, as: nil, type: nil)
+        attributes.push(name)
+
+        self.define_method("#{name}=") do |value|
+          @attributes[name] =
+            case type
+            when :boolean
+              value.to_s == 'true'
+            when :float
+              value.to_f
+            when :integer
+              value.to_i
+            when :time
+              Time.parse(value.to_s)
+            else
+              value
+            end
+        end
+        self.define_method("#{name}") { @attributes[name] }
+
+        if as
+          aliased_attributes[as] = name
+          self.alias_method("#{as}=", "#{name}=")
+          self.alias_method(as, name)
+        end
       end
+
     end
 
     attr_reader :attributes
 
-    def initialize(**args)
-      self.class.default_attributes.merge(args).then do |attrs|
-        attrs.each do |key, val|
-          define_singleton_method("#{key}=") do |val|
-            args[key] = val
-            attributes[key] = val
-          end
-
-          define_singleton_method(key) { args[key] }
-        end
-
-        instance_variable_set(:@attributes, attrs)
-      end
+    def initialize(**kwargs)
+      @attributes ||= {}
+      kwargs.each { |name, value| public_send("#{name}=", value) }
     end
 
     def inspect

--- a/lib/sanity/mutatable.rb
+++ b/lib/sanity/mutatable.rb
@@ -36,11 +36,11 @@ module Sanity
         options.fetch(:only, ALL_MUTATIONS).each do |mutation|
           if DEFAULT_KLASS_MUTATIONS.include? mutation.to_sym
             define_singleton_method(mutation) do |**args|
-              default_args = { resource_klass: self }
-              if !self.is_a?(Sanity::Document)
-                default_type = self.to_s
+              default_args = {resource_klass: self}
+              if !is_a?(Sanity::Document)
+                default_type = to_s
                 default_type[0] = default_type[0].downcase
-                default_args.merge!(_type: default_type)
+                default_args[:_type] = default_type
               end
               Module.const_get("Sanity::Http::#{mutation.to_s.classify}").call(
                 **args.merge(default_args)

--- a/lib/sanity/mutatable.rb
+++ b/lib/sanity/mutatable.rb
@@ -36,7 +36,15 @@ module Sanity
         options.fetch(:only, ALL_MUTATIONS).each do |mutation|
           if DEFAULT_KLASS_MUTATIONS.include? mutation.to_sym
             define_singleton_method(mutation) do |**args|
-              Module.const_get("Sanity::Http::#{mutation.to_s.classify}").call(**args.merge(resource_klass: self))
+              default_args = { resource_klass: self }
+              if !self.is_a?(Sanity::Document)
+                default_type = self.to_s
+                default_type[0] = default_type[0].downcase
+                default_args.merge!(_type: default_type)
+              end
+              Module.const_get("Sanity::Http::#{mutation.to_s.classify}").call(
+                **args.merge(default_args)
+              )
             end
           end
 

--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -40,11 +40,11 @@ module Sanity
       def queryable(**options)
         options.fetch(:only, DEFAULT_KLASS_QUERIES).each do |query|
           define_singleton_method(query) do |**args|
-            default_args = { resource_klass: self }
-            if !self.is_a?(Sanity::Document)
-              default_type = self.to_s
+            default_args = {resource_klass: self}
+            if !is_a?(Sanity::Document)
+              default_type = to_s
               default_type[0] = default_type[0].downcase
-              default_args.merge!(_type: default_type)
+              default_args[:_type] = default_type
             end
             Module.const_get("Sanity::Http::#{query.to_s.classify}").call(
               **args.merge(default_args)

--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -40,7 +40,15 @@ module Sanity
       def queryable(**options)
         options.fetch(:only, DEFAULT_KLASS_QUERIES).each do |query|
           define_singleton_method(query) do |**args|
-            Module.const_get("Sanity::Http::#{query.to_s.classify}").call(**args.merge(resource_klass: self))
+            default_args = { resource_klass: self }
+            if !self.is_a?(Sanity::Document)
+              default_type = self.to_s
+              default_type[0] = default_type[0].downcase
+              default_args.merge!(_type: default_type)
+            end
+            Module.const_get("Sanity::Http::#{query.to_s.classify}").call(
+              **args.merge(default_args)
+            )
           end
           define_singleton_method("#{query}_api_endpoint") { QUERY_ENDPOINTS[query] }
         end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -8,6 +8,7 @@ describe Sanity::Resource do
 
   it { assert_respond_to klass, :attributes }
   it { assert_respond_to klass, :aliased_attributes }
+  it { assert_respond_to klass, :default_attributes }
 
   it { assert_respond_to subject, :attributes }
 end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -7,7 +7,7 @@ describe Sanity::Resource do
   subject { klass.new }
 
   it { assert_respond_to klass, :attributes }
-  it { assert_respond_to klass, :default_attributes }
+  it { assert_respond_to klass, :aliased_attributes }
 
   it { assert_respond_to subject, :attributes }
 end


### PR DESCRIPTION
- Added support to define aliases for attributes using `as`. 
- Added support for a handful of native types using `type`.
- Refactored attribute getter and setter definitions to happen on load instead of at class initialization. This makes it so anyone can override the getter or setters themselves.
- Added default type for querying when using PORO.

I didn't include any tests for this PR since the Sanity::Attributable module does not have any. 