### PR TITLE
Added built in serailization support for a PORO

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ end
 
 ## Serialization
 
-When using a PORO, you can opt-in to automatically serialize your results.
+When using a PORO, you can opt-in to automatically serialize your results. You
+must define all attributes that should be serialized.
 
 ```ruby
 class User < Sanity::Resource

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library also provides other features, like:
 
 - Easy configuration for fast setup and use.
 - A pre-defined class to help make any PORO a "sanity resource"
-- Extensibility in overriding the wrapper of your API response results
+- Extensibility in overriding the serializer for the API response results
 - A small DSL around GROQ queries
 
 ## Contents
@@ -17,6 +17,7 @@ The library also provides other features, like:
 - [Sanity](#sanity)
   - [Contents](#contents)
   - [Getting Started](#getting-started)
+  - [Serialization](#serialization)
   - [Mutating](#mutating)
   - [Querying](#querying)
   - [Development](#development)
@@ -98,6 +99,34 @@ class User
   queryable
   mutatable
 end
+```
+
+## Serialization
+
+When using a PORO, you can opt-in to automatically serialize your results.
+
+```ruby
+class User < Sanity::Resource
+  auto_serialize
+  ...
+end
+```
+
+Additionally, you can configure a custom serializer. See how to define a custom
+serializer [below](#custom-serializer).
+
+```ruby
+class User < Sanity::Resource
+  serializer UserSerializer
+  ...
+end
+```
+
+Finally, at query time you can also pass in a serializer. A serializer specified
+at query time will take priority over any other configuration.
+
+```ruby
+User.where(active: true, serializer: UserSerializer)
 ```
 
 ## Mutating
@@ -217,6 +246,35 @@ GROQ
 
 Sanity::Document.where(groq: groq_query, variables: {name: "Monsters, Inc."})
 ```
+
+## Custom serializer
+
+```ruby
+class UserSerializer
+  class << self
+    def call(...)
+      new(...).call
+    end
+  end
+
+  attr_reader :results
+
+  def initialize(args)
+    @results = args["result"]
+  end
+
+  def call
+    results.map do |result|
+      User.new(
+        _id: result["_id"],
+        _type: result["_type"]
+      )
+    end
+  end
+end
+```
+
+
 
 ## Development
 

--- a/lib/sanity.rb
+++ b/lib/sanity.rb
@@ -12,6 +12,7 @@ require "sanity/http"
 require "sanity/attributable"
 require "sanity/mutatable"
 require "sanity/queryable"
+require "sanity/serializable"
 
 require "sanity/resource"
 require "sanity/resources"

--- a/lib/sanity.rb
+++ b/lib/sanity.rb
@@ -19,4 +19,6 @@ require "sanity/resources"
 
 module Sanity
   class Error < StandardError; end
+
+  RESULT_WRAPPER_DEPRECATION_WARNING = "DEPRECATION: `result_wrapper` is deprecated. Please use `serializer` instead."
 end

--- a/lib/sanity/http/query.rb
+++ b/lib/sanity/http/query.rb
@@ -26,13 +26,12 @@ module Sanity
       # @todo Add query support
       def initialize(**args)
         @resource_klass = args.delete(:resource_klass)
-        if @resource_klass.respond_to?(:default_serializer)
-          klass_serializer = @resource_klass.default_serializer
-        end
+
+        warn RESULT_WRAPPER_DEPRECATION_WARNING if args[:result_wrapper]
         @serializer = args.delete(:serializer) ||
-                      args.delete(:result_wrapper) || # kept for backwards compatibility
-                      klass_serializer ||
-                      Sanity::Http::Results
+          args.delete(:result_wrapper) || # kept for backwards compatibility
+          klass_serializer ||
+          Sanity::Http::Results
       end
 
       # @todo Add query support
@@ -50,6 +49,11 @@ module Sanity
 
           block_given? ? yield(serializer.call(data)) : serializer.call(data)
         end
+      end
+
+      def result_wrapper
+        warn RESULT_WRAPPER_DEPRECATION_WARNING
+        serializer
       end
 
       private
@@ -70,6 +74,12 @@ module Sanity
           "Content-Type": "application/json",
           Authorization: "Bearer #{token}"
         }
+      end
+
+      def klass_serializer
+        return unless @resource_klass.respond_to?(:default_serializer)
+
+        @resource_klass.default_serializer
       end
 
       def uri

--- a/lib/sanity/http/where.rb
+++ b/lib/sanity/http/where.rb
@@ -18,7 +18,9 @@ module Sanity
         @variables = args.delete(:variables) || {}
         @use_post = args.delete(:use_post) || false
 
-        @groq_attributes = args.except(:groq, :use_post, :resource_klass, :result_wrapper)
+        @groq_attributes = args.except(
+          :groq, :use_post, :resource_klass, :serializer, :result_wrapper
+        )
       end
 
       private

--- a/lib/sanity/resource.rb
+++ b/lib/sanity/resource.rb
@@ -8,6 +8,7 @@ module Sanity
   #   Sanity::Attributable
   #   Sanity::Mutatable
   #   Sanity::Queryable
+  #   Sanity::Serializable
   #
   # Sanity::Document and Sanity::Asset both inherit
   # from Sanity::Resource
@@ -26,5 +27,6 @@ module Sanity
     include Sanity::Attributable
     include Sanity::Mutatable
     include Sanity::Queryable
+    include Sanity::Serializable
   end
 end

--- a/lib/sanity/serializable.rb
+++ b/lib/sanity/serializable.rb
@@ -38,17 +38,13 @@ module Sanity
       end
 
       def class_serializer
-        @class_serializer ||= Proc.new do |results|
-          results['result'].map do |result|
+        @class_serializer ||= proc do |results|
+          results["result"].map do |result|
             attributes = result.slice(*self.attributes.map(&:to_s))
-            self.new(**attributes.transform_keys(&:to_sym))
+            new(**attributes.transform_keys(&:to_sym))
           end
         end
       end
-
     end
-
-    attr_reader :default_serializer
-
   end
 end

--- a/lib/sanity/serializable.rb
+++ b/lib/sanity/serializable.rb
@@ -24,17 +24,28 @@ module Sanity
 
     module ClassMethods
       def default_serializer
-        @default_serializer ||= nil
+        @default_serializer ||=
+          if auto_serialize?
+            class_serializer
+          elsif defined?(@serializer)
+            @serializer
+          end
+      end
+
+      def auto_serialize?
+        return @auto_serialize if defined?(@auto_serialize)
+
+        superclass.respond_to?(:auto_serialize?) && superclass.auto_serialize?
       end
 
       private
 
       def auto_serialize
-        @default_serializer = class_serializer
+        @auto_serialize = true
       end
 
       def serializer(serializer)
-        @default_serializer = serializer
+        @serializer = serializer
       end
 
       def class_serializer

--- a/lib/sanity/serializable.rb
+++ b/lib/sanity/serializable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Sanity
+  # Serializable is responsible for configuring auto serialization or a default
+  # serializer. It also defines the default class serializer used when auto
+  # serialization is enabled.
+  #
+  # The auto_serialize macro is used to enable auto serialization.
+  #
+  # @example enables auto serialization
+  #   auto_serialize
+  #
+  # The serializer marco is used to define the default serializer.
+  #
+  # @example default to using a custom defined UserSerializer
+  #   serializer UserSerializer
+  #
+  module Serializable
+    class << self
+      def included(base)
+        base.extend(ClassMethods)
+      end
+    end
+
+    module ClassMethods
+      def default_serializer
+        @default_serializer ||= nil
+      end
+
+      private
+
+      def auto_serialize
+        @default_serializer = class_serializer
+      end
+
+      def serializer(serializer)
+        @default_serializer = serializer
+      end
+
+      def class_serializer
+        @class_serializer ||= Proc.new do |results|
+          results['result'].map do |result|
+            attributes = result.slice(*self.attributes.map(&:to_s))
+            self.new(**attributes.transform_keys(&:to_sym))
+          end
+        end
+      end
+
+    end
+
+    attr_reader :default_serializer
+
+  end
+end

--- a/test/sanity/groq/order_test.rb
+++ b/test/sanity/groq/order_test.rb
@@ -22,7 +22,7 @@ describe Sanity::Groq::Order do
 
       context "when order is a hash with multiple k/v pairs" do
         it "returns expected string" do
-          assert_equal\
+          assert_equal \
             "| order(createdAt desc) | order(updatedAt asc)",
             subject.call(order: {createdAt: :desc, updatedAt: :asc})
         end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -8,6 +8,7 @@ describe Sanity::Resource do
 
   it { assert_respond_to klass, :attributes }
   it { assert_respond_to klass, :default_attributes }
+  it { assert_respond_to klass, :default_serializer }
 
   it { assert_respond_to subject, :attributes }
 end

--- a/test/sanity/serializable_test.rb
+++ b/test/sanity/serializable_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+class CustomSerializer; end
 
 describe Sanity::Serializable do
   describe "class methods" do
@@ -24,12 +25,11 @@ describe Sanity::Serializable do
 
       it { refute_nil subject.default_serializer }
       it {
-        assert_equal subject.default_serializer, subject.send(:class_serializer)
+        assert_equal subject.send(:class_serializer), subject.default_serializer
       }
     end
 
     context "with custom serializer defined" do
-      class CustomSerializer; end
       subject {
         Class.new do
           include Sanity::Serializable

--- a/test/sanity/serializable_test.rb
+++ b/test/sanity/serializable_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Sanity::Serializable do
+  describe "class methods" do
+    context "without auto_serialize defined" do
+      subject {
+        Class.new do
+          include Sanity::Serializable
+        end
+      }
+
+      it { assert_nil subject.default_serializer }
+    end
+
+    context "with auto_serialize defined" do
+      subject {
+        Class.new do
+          include Sanity::Serializable
+          auto_serialize
+        end
+      }
+
+      it { refute_nil subject.default_serializer }
+      it {
+        assert_equal subject.default_serializer, subject.send(:class_serializer)
+      }
+    end
+
+    context "with custom serializer defined" do
+      class CustomSerializer; end
+      subject {
+        Class.new do
+          include Sanity::Serializable
+          serializer CustomSerializer
+        end
+      }
+
+      it { assert_equal CustomSerializer, subject.default_serializer }
+    end
+  end
+end

--- a/test/sanity/serializable_test.rb
+++ b/test/sanity/serializable_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 class CustomSerializer; end
 
+class BaseClass < Sanity::Resource
+  auto_serialize
+end
+
+class InheritedClass < BaseClass; end
+
 describe Sanity::Serializable do
   describe "class methods" do
     context "without auto_serialize defined" do
@@ -24,9 +30,16 @@ describe Sanity::Serializable do
       }
 
       it { refute_nil subject.default_serializer }
-      it {
-        assert_equal subject.send(:class_serializer), subject.default_serializer
-      }
+      it { assert subject.auto_serialize? }
+      it { assert_equal subject.send(:class_serializer), subject.default_serializer }
+    end
+
+    context "with auto_serialize defined on parent of inheritted class" do
+      subject { InheritedClass }
+
+      it { refute_nil subject.default_serializer }
+      it { assert subject.auto_serialize? }
+      it { assert_equal subject.send(:class_serializer), subject.default_serializer }
     end
 
     context "with custom serializer defined" do


### PR DESCRIPTION
- Added support for serialization for a PORO
- Added `auto_serialize` option to opt-in to automatic serialization using the PORO as the serializer.
- Added `serializer` option to configure a custom serializer.
- Changed `result_wrapper` to be `serializer`, but left `result_wrapper` options in place to allow backwards compatibility.